### PR TITLE
Fix owned filter

### DIFF
--- a/app.js
+++ b/app.js
@@ -84,7 +84,7 @@ Vue.createApp({
           case "z-a":
             return b.name.localeCompare(a.name)
           case "owned":
-            return a.owned === b.owned ? a.level.localeCompare(b.level) : a.owned - b.owned
+            return a.owned === b.owned ? a.name.localeCompare(b.level) : a.owned - b.owned
           default:
             return a.level - b.level
         }

--- a/app.js
+++ b/app.js
@@ -84,7 +84,7 @@ Vue.createApp({
           case "z-a":
             return b.name.localeCompare(a.name)
           case "owned":
-            return a.owned === b.owned ? a.name.localeCompare(b.level) : a.owned - b.owned
+            return a.owned === b.owned ? a.name.localeCompare(b.name) : a.owned - b.owned
           default:
             return a.level - b.level
         }


### PR DESCRIPTION
The weapons part of the "not purchased" sort option is currently broken. In the weapons list, the owned option tries to do a `localeCompare` on level rather than name (the gear list uses name), and it causes a js error which breaks the page on most browsers.

This PR changes the weapons owned sort to use name (so a secondary sort on name after sorting by owned) like the gear owned sort.

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/25806177/192165023-3942e5e4-27dc-4357-afe2-254ca3bf166d.png">
