### PR TITLE
Temporarily stop weapon loading

### DIFF
--- a/app.js
+++ b/app.js
@@ -254,7 +254,8 @@ Vue.createApp({
     progress.width = "50%"
 
     //Load weapons
-    this._weapons =[...await fetch("/static/weapon/list.json").then(response => response.json())].map(weapon => ({...weapon, owned:this.has(weapon)}))
+    //Don't load weapons until they're added to the UI because they throw off the count
+    //this._weapons =[...await fetch("/static/weapon/list.json").then(response => response.json())].map(weapon => ({...weapon, owned:this.has(weapon)}))
     progress.width = "70%"
 
     //Load previous settings


### PR DESCRIPTION
Currently, the app loads weapons into the app. They're not showing in the UI, _but they still affect the total in the progress bar_. Filtering only filters gear currently, so regardless of what filters are on, the total count in the progress bar will always be 53 higher than the actual total of the number of items shown.

This can be stopped simply by not loading the weapons list. This PR comments out the code that loads the weapons list (it can be easily reversed once weapons are added simply by uncommenting that code). Feel free to ignore this if you plan to add weapons soon.

<img width="1465" alt="image" src="https://user-images.githubusercontent.com/25806177/192165795-31542334-44f8-4811-a989-8670382876a3.png">
